### PR TITLE
Changing order of refreshActiveData to sort before filtering.

### DIFF
--- a/dist/js/tabulator.js
+++ b/dist/js/tabulator.js
@@ -2796,6 +2796,18 @@ var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol
         table.extensions.selectRow.deselectRows();
       }
 
+       //sort data
+
+       if (table.extExists("sort")) {
+
+        if (table.extensions.sort.hasChanged() || dataChanged) {
+
+          table.extensions.sort.sort();
+
+          dataChanged = true;
+        }
+      }
+
       //filter data
 
       if (table.extExists("filter")) {
@@ -2809,18 +2821,6 @@ var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol
       } else {
 
         self.setActiveRows(self.rows.slice(0));
-      }
-
-      //sort data
-
-      if (table.extExists("sort")) {
-
-        if (table.extensions.sort.hasChanged() || dataChanged) {
-
-          table.extensions.sort.sort();
-
-          dataChanged = true;
-        }
       }
 
       //group data


### PR DESCRIPTION
Need to sort before filtering so that setActiveRows can fetch updated data from the server before the invalid data is sorted.